### PR TITLE
Allow other extensions to launch streamlink via this extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Probably, but you have to consult [the official documentation](https://developer
 
 - "Why only FF57?"
 
-The templates ([1](https://github.com/mdn/webextensions-examples/tree/master/native-messaging/add-on), [2](https://github.com/mdn/webextensions-examples/tree/master/menu-demo)) I used to create this had some lower version limits, so I took the upper one. Since there is already a [functioning addon for FF ≤ 56](https://addons.mozilla.org/en-US/firefox/addon/open-livestreamer/), I didn't check if this addon works with lower versions. 
+The templates ([1](https://github.com/mdn/webextensions-examples/tree/master/native-messaging/add-on), [2](https://github.com/mdn/webextensions-examples/tree/master/menu-demo)) I used to create this had some lower version limits, so I took the upper one. Since there is already a [functioning addon for FF ≤ 56](https://addons.mozilla.org/en-US/firefox/addon/open-livestreamer/), I didn't check if this addon works with lower versions.
 To use [Open with Livestreamer](https://addons.mozilla.org/en-US/firefox/addon/open-livestreamer/), just set the path to "livestreamer" to the streamlink executable, and it works with streamlink.
 
+## Invoking Streamlink from another extension
+```js
+browser.runtime.sendMessage("streamlink.firefox.helper@gmail.com", "https://example.com/your/url/here")
+  .then(onSuccess)
+  .catch(onError);
+```
+
+You can use the built-in management API to check if the extension is installed.

--- a/background.js
+++ b/background.js
@@ -61,7 +61,7 @@ browser.menus.onClicked.addListener((info, tab) => {
   switch (info.menuItemId) {
     case "streamlink-link":
       url = info.linkUrl;
-      
+
       break;
     case "streamlink-page":
       url = info.pageUrl;
@@ -73,5 +73,21 @@ browser.menus.onClicked.addListener((info, tab) => {
     s = browser.runtime.sendNativeMessage(nativeName, url);
     //port.postMessage(info.linkUrl);
     s.then(onResponse, onError);
-  } 
+  }
+});
+
+// Let other extensions invoke this extension.
+browser.onMessageExternal.addListener((url, sender) => {
+  if(url) {
+    // Ensure we got a valid URL
+    try {
+      new URL(url);
+    }
+    catch(e) {
+      return Promise.reject(e);
+    }
+    return browser.runtime.sendNativeMessage(nativeName, url)
+      .then(onResponse, onError);
+  }
+  return Promise.reject();
 });


### PR DESCRIPTION
This lets other extensions ask this extension to launch streamlink, as documented in the README. Note that it gobbles up failures in the native component so it doesn't leak things into the consuming extensions.

This fixes #1 .