### PR TITLE
Add linux instructions & native app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ This allows you to watch livestreams, for example from twitch, with a custom med
 You need to do multiple things for this to work:
 - Install [Python](https://python.org), and add it to your ```PATH``` environment variable.
 - Install [Streamlink](https://github.com/streamlink/streamlink), propably using ```pip install streamlink```. Add the executable to your path.
-- Set ```default-stream best``` (or another quality) in the ```streamlinkrc``` (```found at %APPDATA%\streamlink\streamlinkrc```)
+- Set ```default-stream best``` (or another quality) and a default `player` in the ```streamlinkrc``` (found on Windows at ```%APPDATA%\streamlink\streamlinkrc```, on Linux at `~/.streamlinkrc`).
 - Download and unzip ```streamlink-helper.zip``` from [Releases](https://github.com/plneappl/streamlink-helper/releases) somewhere you can read and write to. Note that location. Then:
-    + Edit ```registry.reg``` with the path to ```streamlink-helper.json``` in that location and execute it, or edit the registry on your own.
-    + Edit ```streamlink-helper.json``` with the path to ```streamlink-helper.bat```.
-    + Edit ```streamlink-helper.bat``` with the path to ```streamlink-helper.py``` (and to Python, if it's not on your path).
-    + If ```streamlink.exe``` is not on your path, edit ```streamlink-helper.py```, replacing ```streamlink.exe``` with the location to it.
+    - **Windows**:
+        + Edit ```registry.reg``` with the path to ```streamlink-helper.json``` in that location and execute it, or edit the registry on your own.
+        + Edit ```streamlink-helper.json``` with the path to ```streamlink-helper.bat```.
+        + Edit ```streamlink-helper.bat``` with the path to ```streamlink-helper.py``` (and to Python, if it's not on your path).
+        + If ```streamlink.exe``` is not on your path, edit ```streamlink-helper.py```, replacing ```streamlink.exe``` with the location to it.
+    - **Linux**:
+        + Ensure Python is in your path. If you have a `python` binary in your terminal that is most likely the case.
+        + Edit `streamlink-helper.json` with the path to `streamlink-helper.py`.
+        + Copy the `streamlink-helper.json` as `streamlink_helper.json` to the appropriate directory according to [this documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_manifests#Linux) (most likely you want to do `cp streamlink-helper.json ~/.mozilla/native-messaging-hosts/streamlink_helper.json`).
+        + If `streamlink` is not in your path, edit `streamlink-helper.py`, replacing `streamlink` with the location to it.
 
 ## FAQ
 
@@ -27,9 +33,9 @@ You need to do multiple things for this to work:
 
 Yes, its way too complicated, but neccessary for FF57. Maybe I could have made it easier, but relative paths don't seem to work in all these files. If you want, you could create an installer for this ;)
 
-- "Does this work on Linux/MacOS?"
+- "Does this work on MacOS?"
 
-Probably, but you have to consult [the official documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) for how to configure your equivalent of a registry, remove the ```.exe```-part from the python file, point directly to the python file instead of a bat and make it executable. YMMV.
+Probably, but you have to consult [the official documentation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) for how to configure your equivalent of a registry, point directly to the python file instead of a bat and make it executable. YMMV.
 
 - "Why only FF57?"
 

--- a/streamlink-helper/streamlink-helper.py
+++ b/streamlink-helper/streamlink-helper.py
@@ -4,12 +4,16 @@ import sys
 import json
 import struct
 import subprocess
+import platform
 
 def launchStreamlink(url):
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx
-  p = subprocess.Popen(["streamlink.exe", url], creationflags = 0x01000000 | subprocess.CREATE_NEW_CONSOLE)
+  if platform.system() == 'Windows':
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx
+    p = subprocess.Popen(['streamlink.exe', url], creationflags = 0x01000000 | subprocess.CREATE_NEW_CONSOLE)
+  else:
+    p = subprocess.Popen(['streamlink', url], stdout = subprocess.PIPE)
   p.wait()
-  
+
 try:
     # Python 3.x version
     # Read a message from stdin and decode it.


### PR DESCRIPTION
 - Add instructions for linux
 - Add note about default player in `.streamlinkrc` to instructions
 - Mark streamlink-helper.py as executable for unix systems
 - Add platform detection in streamlink-helper.py and invoke streamlink in a python 2.7 compatible way. Not sure if it's the best way to do it, my python is very basic. It works on my linux, but I have not tested it on windows.